### PR TITLE
Message formatting missing byte

### DIFF
--- a/scripting/chat-processor.sp
+++ b/scripting/chat-processor.sp
@@ -189,7 +189,10 @@ public Action OnSayText2(UserMsg msg_id, BfRead msg, const int[] players, int pl
 	switch (g_Proto)
 	{
 		case true: PbReadString(msg, "msg_name", sFlag, sizeof(sFlag));
-		case false: BfReadString(msg, sFlag, sizeof(sFlag));
+		case false: {
+			BfReadByte(msg);
+			BfReadString(msg, sFlag, sizeof(sFlag));
+		}
 	}
 	
 	//Trim the flag so there's no potential issues with retrieving the specified format rules.


### PR DESCRIPTION
Need to read an extra byte to get to the string, if not we get a 'Start of Header' along with the string and thus it never finds anything in the message formats stringmap.
Someone will have to test and see if the protobuff version needs a change as well, as I cannot test that.